### PR TITLE
Add cinema API with movies, sessions and bookings

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,3 +1,20 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Movie, Session, Booking
+
+
+@admin.register(Movie)
+class MovieAdmin(admin.ModelAdmin):
+    list_display = ("titulo", "genero", "clasificacion", "activa")
+
+
+@admin.register(Session)
+class SessionAdmin(admin.ModelAdmin):
+    list_display = ("movie", "fecha", "hora", "sala", "precio")
+    list_filter = ("movie", "fecha")
+
+
+@admin.register(Booking)
+class BookingAdmin(admin.ModelAdmin):
+    list_display = ("codigo_reserva", "nombre_cliente", "session", "estado")
+    list_filter = ("estado",)

--- a/api/migrations/0001_initial.py
+++ b/api/migrations/0001_initial.py
@@ -1,0 +1,58 @@
+import uuid
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Movie',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('titulo', models.CharField(max_length=255)),
+                ('descripcion', models.TextField(blank=True)),
+                ('duracion', models.PositiveIntegerField(help_text='Duración en minutos')),
+                ('genero', models.CharField(max_length=100)),
+                ('clasificacion', models.CharField(max_length=50)),
+                ('poster_url', models.URLField(blank=True)),
+                ('activa', models.BooleanField(default=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Session',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('fecha', models.DateField()),
+                ('hora', models.TimeField()),
+                ('sala', models.CharField(max_length=50)),
+                ('precio', models.DecimalField(decimal_places=2, max_digits=8)),
+                ('asientos_totales', models.PositiveIntegerField()),
+                ('asientos_disponibles', models.PositiveIntegerField()),
+                ('movie', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='sessions', to='api.movie')),
+            ],
+            options={'ordering': ['fecha', 'hora']},
+        ),
+        migrations.CreateModel(
+            name='Booking',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('nombre_cliente', models.CharField(max_length=255)),
+                ('email_cliente', models.EmailField(max_length=254)),
+                ('telefono_cliente', models.CharField(blank=True, max_length=20)),
+                ('asientos_seleccionados', models.JSONField()),
+                ('cantidad_asientos', models.PositiveIntegerField()),
+                ('precio_total', models.DecimalField(decimal_places=2, max_digits=10)),
+                ('estado', models.CharField(choices=[('pendiente', 'Pendiente'), ('confirmada', 'Confirmada'), ('cancelada', 'Cancelada')], default='pendiente', max_length=20)),
+                ('codigo_reserva', models.CharField(default=uuid.uuid4, editable=False, max_length=36, unique=True)),
+                ('creado_en', models.DateTimeField(default=django.utils.timezone.now)),
+                ('session', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='bookings', to='api.session')),
+            ],
+        ),
+    ]
+

--- a/api/models.py
+++ b/api/models.py
@@ -1,3 +1,55 @@
 from django.db import models
+from django.utils import timezone
+import uuid
 
-# Create your models here.
+
+class Movie(models.Model):
+    titulo = models.CharField(max_length=255)
+    descripcion = models.TextField(blank=True)
+    duracion = models.PositiveIntegerField(help_text="Duración en minutos")
+    genero = models.CharField(max_length=100)
+    clasificacion = models.CharField(max_length=50)
+    poster_url = models.URLField(blank=True)
+    activa = models.BooleanField(default=True)
+
+    def __str__(self):
+        return self.titulo
+
+
+class Session(models.Model):
+    movie = models.ForeignKey(Movie, related_name='sessions', on_delete=models.CASCADE)
+    fecha = models.DateField()
+    hora = models.TimeField()
+    sala = models.CharField(max_length=50)
+    precio = models.DecimalField(max_digits=8, decimal_places=2)
+    asientos_totales = models.PositiveIntegerField()
+    asientos_disponibles = models.PositiveIntegerField()
+
+    class Meta:
+        ordering = ['fecha', 'hora']
+
+    def __str__(self):
+        return f"{self.movie.titulo} - {self.fecha} {self.hora}"
+
+
+class Booking(models.Model):
+    ESTADOS = [
+        ('pendiente', 'Pendiente'),
+        ('confirmada', 'Confirmada'),
+        ('cancelada', 'Cancelada'),
+    ]
+
+    session = models.ForeignKey(Session, related_name='bookings', on_delete=models.CASCADE)
+    nombre_cliente = models.CharField(max_length=255)
+    email_cliente = models.EmailField()
+    telefono_cliente = models.CharField(max_length=20, blank=True)
+    asientos_seleccionados = models.JSONField()
+    cantidad_asientos = models.PositiveIntegerField()
+    precio_total = models.DecimalField(max_digits=10, decimal_places=2)
+    estado = models.CharField(max_length=20, choices=ESTADOS, default='pendiente')
+    codigo_reserva = models.CharField(max_length=36, unique=True, editable=False, default=uuid.uuid4)
+    creado_en = models.DateTimeField(default=timezone.now)
+
+    def __str__(self):
+        return f"{self.nombre_cliente} - {self.codigo_reserva}"
+

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+
+from .models import Movie, Session, Booking
+
+
+class MovieSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Movie
+        fields = '__all__'
+
+
+class SessionSerializer(serializers.ModelSerializer):
+    movie = MovieSerializer(read_only=True)
+    movie_id = serializers.PrimaryKeyRelatedField(
+        queryset=Movie.objects.all(), source='movie', write_only=True
+    )
+
+    class Meta:
+        model = Session
+        fields = [
+            'id', 'movie', 'movie_id', 'fecha', 'hora', 'sala',
+            'precio', 'asientos_totales', 'asientos_disponibles'
+        ]
+
+
+class BookingSerializer(serializers.ModelSerializer):
+    session = SessionSerializer(read_only=True)
+    session_id = serializers.PrimaryKeyRelatedField(
+        queryset=Session.objects.all(), source='session', write_only=True
+    )
+
+    class Meta:
+        model = Booking
+        fields = [
+            'id', 'session', 'session_id', 'nombre_cliente', 'email_cliente',
+            'telefono_cliente', 'asientos_seleccionados', 'cantidad_asientos',
+            'precio_total', 'estado', 'codigo_reserva', 'creado_en'
+        ]
+        read_only_fields = ['precio_total', 'estado', 'codigo_reserva', 'creado_en']
+

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,0 +1,12 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import MovieViewSet, SessionViewSet, BookingViewSet
+
+
+router = DefaultRouter()
+router.register('movies', MovieViewSet)
+router.register('sessions', SessionViewSet)
+router.register('bookings', BookingViewSet)
+
+urlpatterns = router.urls
+

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,97 @@
-from django.shortcuts import render
+from django.db.models import Count
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
-# Create your views here.
+from .models import Movie, Session, Booking
+from .serializers import MovieSerializer, SessionSerializer, BookingSerializer
+
+
+class MovieViewSet(viewsets.ModelViewSet):
+    queryset = Movie.objects.all()
+    serializer_class = MovieSerializer
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if self.action == 'list':
+            qs = qs.filter(activa=True)
+        return qs
+
+    @action(detail=True, methods=['get'])
+    def sessions(self, request, pk=None):
+        movie = self.get_object()
+        serializer = SessionSerializer(movie.sessions.all(), many=True)
+        return Response(serializer.data)
+
+
+class SessionViewSet(viewsets.ModelViewSet):
+    queryset = Session.objects.select_related('movie').all()
+    serializer_class = SessionSerializer
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if self.action == 'list':
+            qs = qs.filter(movie__activa=True, asientos_disponibles__gt=0)
+        return qs
+
+    @action(detail=False, methods=['get'], url_path='by_movie')
+    def by_movie(self, request):
+        movie_id = request.query_params.get('movie_id')
+        if not movie_id:
+            return Response([], status=status.HTTP_200_OK)
+        qs = self.get_queryset().filter(movie_id=movie_id)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
+
+
+class BookingViewSet(viewsets.ModelViewSet):
+    queryset = Booking.objects.select_related('session').all()
+    serializer_class = BookingSerializer
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        session = serializer.validated_data['session']
+        cantidad = serializer.validated_data['cantidad_asientos']
+        if session.asientos_disponibles < cantidad:
+            return Response(
+                {'detail': 'No hay suficientes asientos disponibles.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        session.asientos_disponibles -= cantidad
+        session.save()
+        instance = serializer.save(precio_total=session.precio * cantidad)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            self.get_serializer(instance).data,
+            status=status.HTTP_201_CREATED,
+            headers=headers,
+        )
+
+    @action(detail=False, methods=['get'], url_path='stats')
+    def stats(self, request):
+        data = Booking.objects.values('estado').annotate(total=Count('id'))
+        return Response({item['estado']: item['total'] for item in data})
+
+    @action(detail=True, methods=['post'], url_path='confirm')
+    def confirm(self, request, pk=None):
+        booking = self.get_object()
+        if booking.estado != 'pendiente':
+            return Response({'detail': 'La reserva no puede ser confirmada.'}, status=400)
+        booking.estado = 'confirmada'
+        booking.save()
+        return Response({'status': 'confirmada'})
+
+    @action(detail=True, methods=['post'], url_path='cancel')
+    def cancel(self, request, pk=None):
+        booking = self.get_object()
+        if booking.estado == 'cancelada':
+            return Response({'detail': 'La reserva ya está cancelada.'}, status=400)
+        if booking.estado == 'confirmada':
+            session = booking.session
+            session.asientos_disponibles += booking.cantidad_asientos
+            session.save()
+        booking.estado = 'cancelada'
+        booking.save()
+        return Response({'status': 'cancelada'})
+

--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -38,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'api',
 ]
 
 MIDDLEWARE = [
@@ -71,14 +73,32 @@ WSGI_APPLICATION = 'config.wsgi.application'
 
 
 # Database
+# Default configuration targets PostgreSQL but can fall back to SQLite by
+# setting the ``DB_ENGINE`` environment variable to
+# ``django.db.backends.sqlite3``. This makes local development and testing
+# simpler while keeping the project ready for production with PostgreSQL.
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+DB_ENGINE = os.environ.get('DB_ENGINE', 'django.db.backends.postgresql')
+
+if DB_ENGINE == 'django.db.backends.sqlite3':
+    DATABASES = {
+        'default': {
+            'ENGINE': DB_ENGINE,
+            'NAME': BASE_DIR / os.environ.get('DB_NAME', 'db.sqlite3'),
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': DB_ENGINE,
+            'NAME': os.environ.get('DB_NAME', 'cinema'),
+            'USER': os.environ.get('DB_USER', 'postgres'),
+            'PASSWORD': os.environ.get('DB_PASSWORD', 'postgres'),
+            'HOST': os.environ.get('DB_HOST', 'localhost'),
+            'PORT': os.environ.get('DB_PORT', '5432'),
+        }
+    }
 
 
 # Password validation

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('api.urls')),
 ]


### PR DESCRIPTION
## Summary
- configure Postgres-ready database and register api app
- define Movie, Session and Booking models
- implement viewsets, serializers and routes for movies, sessions and bookings

## Testing
- `DB_ENGINE=django.db.backends.sqlite3 python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68988e45915c832d87507b299dbb7e7a